### PR TITLE
Added ignored user agents / error types

### DIFF
--- a/lib/exceptional/config.rb
+++ b/lib/exceptional/config.rb
@@ -14,7 +14,7 @@ module Exceptional
       }
 
       attr_accessor :api_key, :enabled
-      attr_accessor :http_proxy_host, :http_proxy_port, :http_proxy_username, :http_proxy_password
+      attr_accessor :http_proxy_host, :http_proxy_port, :http_proxy_username, :http_proxy_password, :ignored_agents, :ignored_exceptions
       attr_writer :ssl
 
       def load(config_file=nil)
@@ -35,6 +35,8 @@ module Exceptional
             @enabled = env_config['enabled']
             @remote_port = config['remote-port'].to_i unless config['remote-port'].nil?
             @remote_host = config['remote-host'] unless config['remote-host'].nil?
+            @ignored_agents = config['ignored-agents']
+            @ignored_exceptions = config['ignored-exceptions']
           rescue Exception => e
             raise ConfigurationException.new("Unable to load configuration #{config_file} for environment #{application_environment} : #{e.message}")
           end
@@ -61,6 +63,14 @@ module Exceptional
 
       def ssl?
         @ssl ||= DEFAULTS[:ssl]
+      end
+      
+      def ignored_agents
+        @ignored_agents || []
+      end
+      
+      def ignored_exceptions
+        @ignored_exceptions || []
       end
 
       def remote_host

--- a/lib/exceptional/integration/rails.rb
+++ b/lib/exceptional/integration/rails.rb
@@ -7,7 +7,9 @@ if defined? ActionController
   module ActionController
     class Base
       def rescue_action_with_exceptional(exception)
-        unless exception_handled_by_rescue_from?(exception)
+        unless exception_handled_by_rescue_from?(exception) ||
+               Regexp.new(Exceptional::Config.ignored_agents.join('|')) =~ request.user_agent ||
+               Regexp.new(Exceptional::Config.ignored_exceptions.join('|')) =~ exception.class.to_s
           Exceptional::Catcher.handle_with_controller(exception, self, request)
           Exceptional.context.clear!
         end


### PR DESCRIPTION
Example usage:

`exceptional.yml`

``` yaml
ignored-agents:     [Google.ot, Googlebot, msnbot, ia_archiver, Slurp, Exabot, Purebot, Searchbot, bingbot, YandexBot, SiteBot, ScoutJet]
ignored-exceptions: [Memcached::ServerIsMarkedDead, Timeout::Error]
```
