### PR TITLE
Environment specific config (like database.yml)

### DIFF
--- a/lib/exceptional/config.rb
+++ b/lib/exceptional/config.rb
@@ -20,7 +20,8 @@ module Exceptional
       def load(config_file=nil)
         if (config_file && File.file?(config_file))
           begin
-            config = YAML::load_file(config_file)
+            yaml = YAML::load_file(config_file)
+            config = yaml[ENV['RAILS_ENV'] || 'development'] || yaml
             env_config = config[application_environment] || {}
             @api_key = config['api-key'] || env_config['api-key']
 


### PR DESCRIPTION
Works like this

development:
  api-key: somedevkey
production:
  api-key: someprodkey

The default, old version works as well, as in just the plain

api-key: oneapikeyforeverything

Will work with other config options as well.
