### PR TITLE
Update README to illustrate configuring multiple environments within Rails

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,6 +52,19 @@ This Gem/Plugin posts exception data to Exceptional <http://exceptional.io>. Dat
 
 5.  Test with <code>exceptional test</code>
 
+## Multiple Rails environments
+To use Exceptional within multiple Rails environments, edit your
+config/exceptional.yml to look like the following
+
+```
+development:
+  enabled: true
+  api-key: your-dev-api-key
+
+production:
+  enabled: true
+  api-key: you-prod-api-key
+```
 
 ### Exceptional also supports your rack, sinatra and plain ruby apps
 For more information check out our docs site <http://docs.exceptional.io> 


### PR DESCRIPTION
The README does not show how we can configure Exceptional to send to different apps based on the 
environment.

Example configuration collects errors in development and production env and sends to different Exceptional apps accordingly.
