### PR TITLE
Whitelist filter for ENV variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ doc
 log
 pkg/*
 _site
+.idea
+Gemfile.lock

--- a/lib/exceptional.rb
+++ b/lib/exceptional.rb
@@ -23,6 +23,7 @@ module Exceptional
   PROTOCOL_VERSION = 5
   CLIENT_NAME = 'getexceptional-gem'
   ENVIRONMENT_FILTER = []
+  ENVIRONMENT_WHITELIST = %w(HOME PATH PWD RUBYOPT GEM_HOME RACK_ENV RAILS_ENV BUNDLE_GEMFILE BUNDLE_BIN_PATH)
 
   def self.logger
     ::Exceptional::LogFactory.logger

--- a/lib/exceptional/application_environment.rb
+++ b/lib/exceptional/application_environment.rb
@@ -33,7 +33,10 @@ module Exceptional
 
     def self.extract_environment(env)
       env.reject do |k, v|
-        (k =~ /^HTTP_/) || Exceptional::ENVIRONMENT_FILTER.include?(k)
+        is_http_header = (k =~ /^HTTP_/)
+        is_filtered = Exceptional::ENVIRONMENT_FILTER.include?(k)
+        matches_whitelist = Exceptional::ENVIRONMENT_WHITELIST.any?{|whitelist_filter| whitelist_filter.is_a?(Regexp) ? k =~ whitelist_filter : k.eql?(whitelist_filter)}
+        is_http_header || is_filtered || !matches_whitelist
       end
     end
 


### PR DESCRIPTION
Heroku exposes lots of sensitive configuration, including passwords/api_keys, via ENV variables. I don't want these sent to exceptional.
This change adds a Exceptional::ENVIRONMENT_WHITELIST, similar to Exceptional::ENVIRONMENT_FILTER which all ENV variables must match before being sent to exceptional. It supports either exact matching of strings or matching of Regexp's
