### PR TITLE
Fix delayed job integration

### DIFF
--- a/lib/exceptional/integration/dj.rb
+++ b/lib/exceptional/integration/dj.rb
@@ -1,7 +1,7 @@
 if Delayed::Worker.method_defined? :handle_failed_job
   class Delayed::Worker
     def handle_failed_job_with_exceptional(job, e)
-      Exceptional.handle(e, "Delayed::Worker \"#{self.name}\" died")
+      Exceptional.handle(e, "Delayed::Job #{job.name}")
       handle_failed_job_without_exceptional(job, e)
       Exceptional.context.clear!
     end

--- a/spec/dj_integration_spec.rb
+++ b/spec/dj_integration_spec.rb
@@ -24,19 +24,16 @@ describe 'Delayed Job integration' do
     module Delayed
       class Worker
         def handle_failed_job(job, exception); end
-        def name; "My worker"; end
       end
     end
     load File.join(File.dirname(__FILE__), '..', 'lib', 'exceptional', 'integration', 'dj.rb')
     @worker =  Delayed::Worker.new
     @exception = StandardError.new
-    @job = "dummy"
+    @job = mock(:name => "My delayed job")
   end
   describe "For Delayed Job > 1.8.5" do
-    before(:each) do
-    end
     it "should handle exceptions with Exceptional" do
-      Exceptional.should_receive(:handle).with(@exception, 'Delayed::Worker "My worker" died')
+      Exceptional.should_receive(:handle).with(@exception, 'Delayed::Job My delayed job')
       @worker.handle_failed_job(@job, @exception)
     end
     it "should clear context" do


### PR DESCRIPTION
The current delayed job integration only works for delayed job 1.8.4 and earlier (1.8.5 came out 2 years ago). This hasn't been apparent because exceptions were being swallowed when the integration was being applied. This patch does 2 things:
1. fixes the DJ integration to work with DJ > 1.8.4
2. removes the exception-swallowing behavior. This behavior wasn't specced and nothing was being reported to the user, not even in `STD.err`, so I made the call to completely remove it. If you would like to put it back in for some reason, then the problem should at least be logged to `STD.err`, and maybe reported with `Exceptional`, if `should_send_to_api?` is true.

Let me know what you think.

John
