### PR TITLE
Makes log creation safer with nil Rails loggers.

### DIFF
--- a/lib/exceptional/log_factory.rb
+++ b/lib/exceptional/log_factory.rb
@@ -30,8 +30,8 @@ module Exceptional
         end
         log
       rescue
-        return Rails.logger if defined?(Rails) && defined?(Rails.logger)
-        return RAILS_DEFAULT_LOGGER if defined?(RAILS_DEFAULT_LOGGER)
+        return Rails.logger if defined?(Rails) && defined?(Rails.logger) && Rails.logger
+        return RAILS_DEFAULT_LOGGER if defined?(RAILS_DEFAULT_LOGGER) && RAILS_DEFAULT_LOGGER
         return Logger.new(STDERR)
       end
     end


### PR DESCRIPTION
> On a pure Rack app that uses some Rails based middleware like Devise, Rails.logger
> can be defined, but nil. In that case, the safest behavior is probably to continue
> on until we return a new Logger to STDERR.
> 
> This is especially true on Heroku where we will definitely end up in the rescue
> block.

I ran into this problem today. Though it's probably an edge case—we're using Devise for its ActiveRecord helpers, not the controller parts, and I'm guessing most people aren't using it that way—I can't think of a way this change would negatively impact the standard use-cases.

Thanks!
