### PR TITLE
Configuration driven ignored user agents and exceptions are completely ignored

### DIFF
--- a/lib/exceptional/config.rb
+++ b/lib/exceptional/config.rb
@@ -51,8 +51,8 @@ module Exceptional
             @enabled = env_config['enabled']
             @remote_port = config['remote-port'].to_i unless config['remote-port'].nil?
             @remote_host = config['remote-host'] unless config['remote-host'].nil?
-            @ignored_agents = config['ignored-agents']
-            @ignored_exceptions = config['ignored-exceptions']
+            @ignore_user_agents = config['ignore-user-agents']
+            @ignore_exceptions = config['ignore-exceptions']
             @send_to = env_config['send_to'] || DEFAULTS[:send_to]
 
             valid_send_to = %w(api log stdout)
@@ -90,11 +90,11 @@ module Exceptional
       def send_to
         @send_to ||= DEFAULTS[:send_to]
       end
-      
+
       def ignore_user_agents
         @ignore_user_agents ||= []
       end
-      
+
       def ignore_exceptions
         @ignore_exceptions ||= []
       end

--- a/spec/exceptional/config_spec.rb
+++ b/spec/exceptional/config_spec.rb
@@ -25,7 +25,7 @@ describe Exceptional::Config, 'defaults' do
     %w(development test).each do |env|
       Exceptional::Config.stub!(:application_environment).and_return(env)
       Exceptional::Config.should_send_to_api?.should == false
-    end    
+    end
   end
   it "be enabled based on environment by default" do
     %w(production staging).each do |env|
@@ -50,12 +50,14 @@ describe Exceptional::Config, 'defaults' do
       Exceptional::Config.http_proxy_password.should == 'jack'
       Exceptional::Config.http_open_timeout.should == 5
       Exceptional::Config.http_read_timeout.should == 10
+      Exceptional::Config.ignore_user_agents.should == %w(Googlebot msnbot)
+      Exceptional::Config.ignore_exceptions.should == %w(Mongoid::Errors::DocumentNotFound)
     end
-    it "allow disable production environment" do      
+    it "allow disable production environment" do
       Exceptional::Config.load('spec/fixtures/exceptional_disabled.yml')
       Exceptional::Config.api_key.should == 'abc123'
       Exceptional::Config.should_send_to_api?.should == false
-    end    
+    end
     it "allow olded format for exception.yml" do
       Exceptional::Config.load('spec/fixtures/exceptional_old.yml')
       Exceptional::Config.api_key.should == 'abc123'

--- a/spec/fixtures/exceptional.yml
+++ b/spec/fixtures/exceptional.yml
@@ -8,3 +8,5 @@ http-proxy-username: bob
 http-proxy-password: jack
 http-open-timeout: 5
 http-read-timeout: 10
+ignore-user-agents: [Googlebot, msnbot]
+ignore-exceptions: ["Mongoid::Errors::DocumentNotFound"]


### PR DESCRIPTION
Commit 2a34eaeb80106269eba3a376129ac26a85ca4682 refactored the user-agent and exception sniffing code but did not take into account the ability to configure these settings from `exceptional.yml`:

https://github.com/exceptional/exceptional/blob/0381b29bf1e6d0376e38ff9d48536104698640f4/lib/exceptional/config.rb#L54-L55

i.e. `ignored_agents` and `ignored_exceptions` **!=** `ignore_user_agents` and `ignore_exceptions`.
