### PR TITLE
Add a deprecation notice

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,13 @@
+# DEPRECATION NOTICE
+
+[exceptional.io](http://exceptional.io) was officially shutdown on September 1, 2016 in favor of [Airbrake](https://airbrake.io).
+
+The [exceptional notifier](https://github.com/exceptional/exceptional) is now officially deprecated.
+
+This repository is no longer accepting pull requests or issues.
+
+The Exceptional team recommends using [Airbrake](https://airbrake.io) moving forward.
+
 # Exceptional <http://exceptional.io>
 
 Exceptional helps you track errors in your Ruby apps


### PR DESCRIPTION
Adds a deprecation notice to the README indicating the exceptional.io shutdown.

**Timeline of events**

| Date         |  Notice |
| ------------- | ------------- |
| 8/26/2014 | Sunset notice sent to Exceptional customers. Migrate to Airbrake notifiers |
| 11/1/2014 | First day exceptional notifiers were proxied to Airbrake |
| 5/18/2016 | First notice of exceptional endpoint shutdown |
| 7/1/2016 | Second notice of exceptional endpoint shutdown |
| 7/26/2016 | Third notice of exceptional shutdown |
| 8/24/2016 | Final reminder of exceptional shutdown |
| 9/1/2016 | Exceptional shutdown | 

Closes #19 
Closes #25
Closes #33 
Closes #37 
Closes #41 
Closes #42 
Closes #46
Closes #47 
Closes #48 
Closes #49 
Closes #50 
Closes #52
